### PR TITLE
High DPI fix

### DIFF
--- a/BG3 Mini Tool/Program.cs
+++ b/BG3 Mini Tool/Program.cs
@@ -10,7 +10,13 @@ namespace BG3_Mini_Tool
         {
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
-            ApplicationConfiguration.Initialize();
+
+            // Instead of using the default font and display settings,
+            // we set the high DPI mode to DpiUnaware to allow the application to scale properly.
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.SetHighDpiMode(HighDpiMode.DpiUnaware);
+            
             Application.Run(new Form1());
         }
     }

--- a/BG3 Mini Tool/Program.cs
+++ b/BG3 Mini Tool/Program.cs
@@ -11,8 +11,8 @@ namespace BG3_Mini_Tool
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
 
-            // Instead of using the default font and display settings,
-            // we set the high DPI mode to DpiUnaware to allow the application to scale properly.
+            // Configure the application to properly scale on high DPI displays by setting the HighDpiMode to DpiUnaware.
+            // This ensures consistent scaling behavior without adjusting for DPI changes.
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.SetHighDpiMode(HighDpiMode.DpiUnaware);


### PR DESCRIPTION
## Summary
Updates initialization parameters to ensure proper DPI scaling on high-resolution displays. Instead of relying on the default configuration initializer, we explicitly set the parameters, maintaining their values while changing the HighDpiMode to DpiUnaware. This adjustment prevents the application window from scaling in response to DPI changes, ensuring a consistent scale factor of 100%.

## Screenshots

<details>

<summary>Res: 1280x1024 | Scale: 100%</summary>

![image](https://github.com/Padme4000/BG3-Mini-Tool/assets/1672704/a3adede6-90bb-4ba1-a57b-58ea074b838b)

</details>

<details>

<summary>Res: 1920x1080 | Scale: 125%</summary>

![image](https://github.com/Padme4000/BG3-Mini-Tool/assets/1672704/c7441451-e10d-4b8f-a2d7-c754839e8afb)

</details>

<details>

<summary>Res: 3840x2160 | Scale: 150%</summary>

![image](https://github.com/Padme4000/BG3-Mini-Tool/assets/1672704/20b4556a-93b6-4441-b49b-3ba8a6c3f36c)

</details>